### PR TITLE
gallery.html > path option

### DIFF
--- a/layouts/shortcodes/gallery.html
+++ b/layouts/shortcodes/gallery.html
@@ -9,6 +9,7 @@ Documentation and licence at https://github.com/thkukuk/hugo-easy-gallery/
 {{- $thumbnailSize := .Get "thumbnail-size" | default "300x300" -}}
 {{- $images := (.Page.Resources.ByType "image") -}}
 {{- if .Get "match" }}{{ $images = (.Page.Resources.Match (.Get "match")) }}{{ end -}}
+{{ if .Get "path" }}{{ $path := printf "%s/*" (.Get "path") }}{{ $images = (.Page.Resources.Match $path) }}{{ end }}
 {{- $sortOrder := .Get "sort" | default (.Site.Params.Gallery.Sort | default "asc") -}}
 {{- $siteUseExif := .Site.Params.Gallery.UseExif -}}
 


### PR DESCRIPTION
add the ability to indicate a specific folder from which to create the image gallery

shortcode example : 

`{{< gallery path="gallery-1"  />}}`

→ make a gallery from `post/gallery-1`