### PR TITLE
fix hugo relURL in load-photoswipe

### DIFF
--- a/layouts/shortcodes/load-photoswipe.html
+++ b/layouts/shortcodes/load-photoswipe.html
@@ -9,13 +9,13 @@ Documentation and licence at https://github.com/thkukuk/hugo-photoswipe5-gallery
 
 <!-- Photoswipe css/js libraries -->
 <script type="module">
-import PhotoSwipeLightbox from '/assets/photoswipe5/photoswipe-lightbox.esm.js';
-import PhotoSwipeDynamicCaption from '/assets/photoswipe-dynamic-caption-plugin/photoswipe-dynamic-caption-plugin.esm.js';
+import PhotoSwipeLightbox from {{ '/assets/photoswipe5/photoswipe-lightbox.esm.js' | relURL }};
+import PhotoSwipeDynamicCaption from {{ '/assets/photoswipe-dynamic-caption-plugin/photoswipe-dynamic-caption-plugin.esm.js' | relURL }};
 
 const lightbox = new PhotoSwipeLightbox({
   gallery: '#photoswipe5-gallery',
   childSelector: '.pswp-gallery__item',
-  pswpModule: () => import('/assets/photoswipe5/photoswipe.esm.js'),
+  pswpModule: () => import({{ '/assets/photoswipe5/photoswipe.esm.js' | relURL }}),
   bgOpacity: 0.95,
   loop: false,
 });
@@ -27,6 +27,6 @@ const captionPlugin = new PhotoSwipeDynamicCaption(lightbox, {
 });
 </script>
 
-<link rel="stylesheet" href="/assets/photoswipe5/photoswipe.css">
-<link rel="stylesheet" href="/assets/photoswipe-dynamic-caption-plugin/photoswipe-dynamic-caption-plugin.css">
+<link rel="stylesheet" href={{ "/assets/photoswipe5/photoswipe.css"  | relURL }}>
+<link rel="stylesheet" href={{ "/assets/photoswipe-dynamic-caption-plugin/photoswipe-dynamic-caption-plugin.css" | relURL }}>
 {{ end -}}

--- a/layouts/shortcodes/load-photoswipe.html
+++ b/layouts/shortcodes/load-photoswipe.html
@@ -9,13 +9,14 @@ Documentation and licence at https://github.com/thkukuk/hugo-photoswipe5-gallery
 
 <!-- Photoswipe css/js libraries -->
 <script type="module">
-import PhotoSwipeLightbox from {{ '/assets/photoswipe5/photoswipe-lightbox.esm.js' | relURL }};
-import PhotoSwipeDynamicCaption from {{ '/assets/photoswipe-dynamic-caption-plugin/photoswipe-dynamic-caption-plugin.esm.js' | relURL }};
+  <!-- {{baseURL}} -->
+import PhotoSwipeLightbox from {{ 'assets/photoswipe5/photoswipe-lightbox.esm.js' | relURL }};
+import PhotoSwipeDynamicCaption from {{ 'assets/photoswipe-dynamic-caption-plugin/photoswipe-dynamic-caption-plugin.esm.js' | relURL }};
 
 const lightbox = new PhotoSwipeLightbox({
   gallery: '#photoswipe5-gallery',
   childSelector: '.pswp-gallery__item',
-  pswpModule: () => import({{ '/assets/photoswipe5/photoswipe.esm.js' | relURL }}),
+  pswpModule: () => import({{ 'assets/photoswipe5/photoswipe.esm.js' | relURL }}),
   bgOpacity: 0.95,
   loop: false,
 });
@@ -27,6 +28,6 @@ const captionPlugin = new PhotoSwipeDynamicCaption(lightbox, {
 });
 </script>
 
-<link rel="stylesheet" href={{ "/assets/photoswipe5/photoswipe.css"  | relURL }}>
-<link rel="stylesheet" href={{ "/assets/photoswipe-dynamic-caption-plugin/photoswipe-dynamic-caption-plugin.css" | relURL }}>
+<link rel="stylesheet" href={{ "assets/photoswipe5/photoswipe.css"  | relURL }}>
+<link rel="stylesheet" href={{ "assets/photoswipe-dynamic-caption-plugin/photoswipe-dynamic-caption-plugin.css" | relURL }}>
 {{ end -}}


### PR DESCRIPTION
First of all Hello! And thanks for this nice code. 

I tried it in my first gitlab pages + hugo site, in framagit.org, wich deploys `framagit.org/<group>/<repo>` under the URL `https://<group>.frama.io/<repo>/`

The gallery page did it well, but  the pictures' pages were basic links to images, they loose titles, CSS and carousel.

I think this PR fixes it.